### PR TITLE
Spin up a Redis server on a container using docker compose and integrate it with application

### DIFF
--- a/configurations/.env.sample
+++ b/configurations/.env.sample
@@ -10,3 +10,7 @@ RDS_NAME=database name
 
 # MongoDB Configurations
 MONGO_URI=URI of the MongoDB cluster
+
+# Cache Server Configurations
+REDIS_HOST=host of the Redis server
+REDIS_PORT=port of the Redis server

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,9 +9,16 @@ services:
     working_dir: /server
     command: uvicorn server.main:app --host 0.0.0.0 --port 8000 --reload
     env_file:
-      - .env
+      - configurations/.env
     volumes:
       - .:/server
     ports:
       - "8000:8000"
+    restart: on-failure
+
+  redis:
+    container_name: redis
+    image: redis:latest
+    ports:
+      - "6379:6379"
     restart: on-failure

--- a/poetry.lock
+++ b/poetry.lock
@@ -22,6 +22,18 @@ test = ["contextlib2", "coverage[toml] (>=4.5)", "hypothesis (>=4.0)", "mock (>=
 trio = ["trio (>=0.16,<0.22)"]
 
 [[package]]
+name = "async-timeout"
+version = "4.0.2"
+description = "Timeout context manager for asyncio programs"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "async-timeout-4.0.2.tar.gz", hash = "sha256:2163e1640ddb52b7a8c80d0a67a08587e5d245cc9c553a74a847056bc2976b15"},
+    {file = "async_timeout-4.0.2-py3-none-any.whl", hash = "sha256:8ca1e4fcf50d07413d66d1a5e416e42cfdf5851c981d679a09851a6853383b3c"},
+]
+
+[[package]]
 name = "beanie"
 version = "1.19.0"
 description = "Asynchronous Python ODM for MongoDB"
@@ -1188,6 +1200,25 @@ files = [
 ]
 
 [[package]]
+name = "redis"
+version = "4.5.5"
+description = "Python client for Redis database and key-value store"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "redis-4.5.5-py3-none-any.whl", hash = "sha256:77929bc7f5dab9adf3acba2d3bb7d7658f1e0c2f1cafe7eb36434e751c471119"},
+    {file = "redis-4.5.5.tar.gz", hash = "sha256:dc87a0bdef6c8bfe1ef1e1c40be7034390c2ae02d92dcd0c7ca1729443899880"},
+]
+
+[package.dependencies]
+async-timeout = {version = ">=4.0.2", markers = "python_full_version <= \"3.11.2\""}
+
+[package.extras]
+hiredis = ["hiredis (>=1.0.0)"]
+ocsp = ["cryptography (>=36.0.1)", "pyopenssl (==20.0.1)", "requests (>=2.26.0)"]
+
+[[package]]
 name = "ruff"
 version = "0.0.267"
 description = "An extremely fast Python linter, written in Rust."
@@ -1690,4 +1721,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "47143134668ba778946e9387fdfb36572238b1adadbbe47e4fe257b553f35e2c"
+content-hash = "5c3d5febfe0bf29b0271be9de1300cd8ac3d5f1c97c135a2fe220ca66ef023d2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ pytest = "^7.3.1"
 coverage = "^7.2.5"
 python-decouple = "^3.8"
 psycopg2 = "^2.9.6"
+redis = "^4.5.5"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^3.3.1"

--- a/server/config/environments/base.py
+++ b/server/config/environments/base.py
@@ -23,6 +23,10 @@ class BaseConfig(RootConfig):
     # MongoDB Configurations
     MONGO_URI: str
 
+    # Cache Servers Configurations
+    REDIS_HOST: str
+    REDIS_PORT: int
+
     class Config:
         env_file = "configurations/.env"
 

--- a/server/main.py
+++ b/server/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 
 from server.config.factory import settings
-from server.models.managers import create_db_and_tables, pool_database_clients
+from server.models.managers import create_db_and_tables, ping_redis_server, pool_database_clients
 
 app = FastAPI()
 
@@ -17,6 +17,10 @@ async def on_startup():
     print("Pooling NoSQL database connections...")
     await pool_database_clients()
     print("NoSQL database connections pooled!")
+
+    print("Ping Redis server...")
+    ping_redis_server()
+    print("Redis server pinged!")
 
     print("Startup complete!")
 

--- a/server/models/managers.py
+++ b/server/models/managers.py
@@ -3,6 +3,7 @@ from typing import List
 from beanie import init_beanie
 from motor.motor_asyncio import AsyncIOMotorClient
 from pydantic import parse_obj_as
+from redis import Redis
 from sqlmodel import create_engine
 
 from server.config.factory import settings
@@ -41,3 +42,12 @@ async def pool_database_clients():
             database=client[mapper.database_name],
             document_models=mapper.model_paths,
         )
+
+
+def get_redis_client():
+    return Redis(host=settings.REDIS_HOST, port=settings.REDIS_PORT)
+
+
+def ping_redis_server():
+    client = get_redis_client()
+    return client.ping()


### PR DESCRIPTION
This pull request adds functionality to spin up a Redis server using Docker Compose and integrate it with an application. The Docker Compose file includes the configuration to set up a Redis container, allowing the application to leverage Redis for caching or other data storage needs. Installing necessary packages and integrating Redis with the application enables improved performance and scalability, as well as the ability to utilize Redis features such as key-value storage, pub/sub messaging, and more.