### PR TITLE
Add CLI application to run application using different modes and configuration easily

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,3 +159,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# data files
+*.db

--- a/manage.py
+++ b/manage.py
@@ -1,0 +1,21 @@
+import os
+import subprocess
+
+import uvicorn
+from typer import Typer
+
+app = Typer()
+
+
+@app.command(name="runserver")
+def run_api_server(mode: str = "development"):
+    os.environ["MODE"] = mode
+
+    if mode == "development":
+        subprocess.Popen("wsl redis-server", shell=True)
+
+    uvicorn.run("server.main:app", host="0.0.0.0", port=8000, reload=True)
+
+
+if __name__ == "__main__":
+    app()

--- a/poetry.lock
+++ b/poetry.lock
@@ -1711,6 +1711,28 @@ files = [
 ]
 
 [[package]]
+name = "typer"
+version = "0.9.0"
+description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "typer-0.9.0-py3-none-any.whl", hash = "sha256:5d96d986a21493606a358cae4461bd8cdf83cbf33a5aa950ae629ca3b51467ee"},
+    {file = "typer-0.9.0.tar.gz", hash = "sha256:50922fd79aea2f4751a8e0408ff10d2662bd0c8bbfa84755a699f3bada2978b2"},
+]
+
+[package.dependencies]
+click = ">=7.1.1,<9.0.0"
+typing-extensions = ">=3.7.4.3"
+
+[package.extras]
+all = ["colorama (>=0.4.3,<0.5.0)", "rich (>=10.11.0,<14.0.0)", "shellingham (>=1.3.0,<2.0.0)"]
+dev = ["autoflake (>=1.3.1,<2.0.0)", "flake8 (>=3.8.3,<4.0.0)", "pre-commit (>=2.17.0,<3.0.0)"]
+doc = ["cairosvg (>=2.5.2,<3.0.0)", "mdx-include (>=1.4.1,<2.0.0)", "mkdocs (>=1.1.2,<2.0.0)", "mkdocs-material (>=8.1.4,<9.0.0)", "pillow (>=9.3.0,<10.0.0)"]
+test = ["black (>=22.3.0,<23.0.0)", "coverage (>=6.2,<7.0)", "isort (>=5.0.6,<6.0.0)", "mypy (==0.910)", "pytest (>=4.4.0,<8.0.0)", "pytest-cov (>=2.10.0,<5.0.0)", "pytest-sugar (>=0.9.4,<0.10.0)", "pytest-xdist (>=1.32.0,<4.0.0)", "rich (>=10.11.0,<14.0.0)", "shellingham (>=1.3.0,<2.0.0)"]
+
+[[package]]
 name = "typing-extensions"
 version = "4.5.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
@@ -2007,4 +2029,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "5d91c024fa330899c1035e41e6883da517e492614f49de710202bf267f8c62cb"
+content-hash = "adba6379f960c3231ad426d2389fd6b749afa869cfcbb01f83932a9663a52888"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ redis = "^4.5.5"
 pydash = "^7.0.3"
 python-jose = {extras = ["cryptography"], version = "^3.3.0"}
 passlib = {extras = ["bcrypt"], version = "^1.7.4"}
+typer = "^0.9.0"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^3.3.1"

--- a/server/config/environments/sqlite_test.py
+++ b/server/config/environments/sqlite_test.py
@@ -1,0 +1,9 @@
+from server.config.environments.base import BaseConfig
+
+
+class SQLiteTestConfig(BaseConfig):
+    DEBUG: bool = True
+    MODE: str = "sqlite-test"
+
+    class Config:
+        env_file = "configurations/.env.sqlite"

--- a/server/config/factory.py
+++ b/server/config/factory.py
@@ -5,6 +5,7 @@ from decouple import config
 from server.config.environments.base import BaseConfig
 from server.config.environments.development import DevelopmentConfig
 from server.config.environments.production import ProductionConfig
+from server.config.environments.sqlite_test import SQLiteTestConfig
 from server.config.environments.staging import StagingConfig
 
 
@@ -17,6 +18,8 @@ class SettingsFactory:
             return StagingConfig()
         elif self.mode == "production":
             return ProductionConfig()
+        elif self.mode == "sqlite-test":  # pragma: no cover
+            return SQLiteTestConfig()
         else:  # pragma: no cover
             return DevelopmentConfig()
 


### PR DESCRIPTION
This pull request introduces two new features to enhance the functionality of the application.

1. **Added new config option for SQLite testing**: A new configuration option has been added to support testing with SQLite as the database backend as a fallback when PostgreSQL configurations are not available. The new configuration option ensures fault tolerance to a certain extent.

2. **Added CLI app to run the application with different modes**: A CLI (Command-Line Interface) application has been included to provide flexibility in running the application with different modes. This CLI app allows developers to specify the desired mode (e.g., development, production, testing) when starting the application. It enhances the application's usability by simplifying the process of running it in various environments and configurations.

These commits contribute to improving the overall testing capabilities and application launch options, making it more convenient and adaptable for different scenarios.